### PR TITLE
Use opam 1.2 instead of opam 2.0

### DIFF
--- a/autoci.opam
+++ b/autoci.opam
@@ -1,9 +1,6 @@
-opam-version: "2.0"
+opam-version: "1.2"
 version: "0.1"
 synopsis: "Generate cloud-based CI config for OCaml projects"
-description: """
-Consults information in opam files and other build data to automatically generate CI invocations for OCaml projects.  It makes use of OCaml CI helpers at https://github.com/ocaml/ocaml-ci-scripts .  It is also intended to have some linting functionality, for use in managing CI configurations across multi-repository projects.
-"""
 maintainer: "Mindy Preston <meetup@yomimono.org>"
 authors: "Mindy Preston <meetup@yomimono.org>"
 license: "MIT"
@@ -21,8 +18,8 @@ depends: [
   "cmdliner"
   "fmt"
   "fpath"
-  "ocaml" {>= "4.03.0"}
   "opam-format"
   "opam-state"
   "yaml"
 ]
+available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
This allows people who still use opam 1.2 to try autoci.