### PR TITLE
autoappveyor: Add a extra test for windows 32bits

### DIFF
--- a/src/appveyor.ml
+++ b/src/appveyor.ml
@@ -20,9 +20,27 @@ let to_yaml config : Yaml.yaml =
                                              ("CYG_ROOT", "C:\\cygwin64")::
                                              custom_globals)
   in
-  let test_list : yaml = `A List.(map (fun test ->
-      `O (yaml_assoc_list @@ Test.test_info_to_assoc_list test))
-      config.tests)
+  let mingw64_to_mingw32 s =
+    try
+      let idx = String.rindex s '+' in
+      let len = String.length s in
+      match String.sub s idx (len - idx) with
+      | "+mingw64c" -> String.sub s 0 idx ^ "+mingw32c"
+      | _ -> s
+    with
+    | Not_found -> s
+  in
+  let test32 test =
+    ("CYG_ROOT", "C:\\cygwin")::
+    List.map (function ("OPAM_SWITCH" as k, v) -> (k, mingw64_to_mingw32 v) | x -> x) test
+  in
+  let test_list : yaml =
+    let l = List.map (Test.test_info_to_assoc_list) config.tests in
+    let l = match List.rev l with
+      | [] -> []
+      | x::xs -> (List.rev_append xs (x :: [test32 x]))
+    in
+    `A (List.map (fun test -> `O (yaml_assoc_list test)) l)
   in
   let yaml_matrix = no_anchor "matrix", test_list in
   `O [ yaml_array ~name:"platform" platforms;


### PR DESCRIPTION
I'm not sure if this should be part of autoci by default or if it should stay as a configuration done afterwards.
I'm also unsure if this is fine with the travis_to_appveyor tool as it also add this extra test.